### PR TITLE
Fix #47 - no PageSize shows no data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A simple Table Control for Blazor with Sorting, Paging and Filtering
 
 ## Features
 - Column Reordering
-- Edit Mode ([Template Switching](/src/BlazorTable.Sample/Pages/EditMode.razor))
+- Edit Mode ([Template Switching](/src/BlazorTable.Sample.Shared/Pages/EditMode.razor))
 - Client Side
 	- Paging
 	- Sorting

--- a/src/BlazorTable.Sample.Shared/BlazorTable.Sample.Shared.csproj
+++ b/src/BlazorTable.Sample.Shared/BlazorTable.Sample.Shared.csproj
@@ -6,14 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="wwwroot\**" />
-    <Content Remove="wwwroot\**" />
-    <EmbeddedResource Remove="wwwroot\**" />
-    <None Remove="wwwroot\**" />
-  </ItemGroup>
-
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.1.0-preview4.19579.2" />

--- a/src/BlazorTable.Sample.Shared/BlazorTable.Sample.Shared.csproj
+++ b/src/BlazorTable.Sample.Shared/BlazorTable.Sample.Shared.csproj
@@ -5,16 +5,18 @@
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Remove="wwwroot\**" />
+    <Content Remove="wwwroot\**" />
+    <EmbeddedResource Remove="wwwroot\**" />
+    <None Remove="wwwroot\**" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.1.0-preview4.19579.2" />
-  </ItemGroup>
-
-
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
   </ItemGroup>
 
 

--- a/src/BlazorTable/Components/Table.razor.cs
+++ b/src/BlazorTable/Components/Table.razor.cs
@@ -9,6 +9,8 @@ namespace BlazorTable
 {
     public partial class Table<TableItem> : ITable<TableItem>
     {
+        const int DEFAULT_PAGE_SIZE = 10;
+
         [Parameter(CaptureUnmatchedValues = true)]
         public IReadOnlyDictionary<string, object> UnknownParameters { get; set; }
 
@@ -25,7 +27,7 @@ namespace BlazorTable
         public Expression<Func<TableItem, string>> TableRowClass { get; set; }
 
         [Parameter]
-        public int PageSize { get; set; }
+        public int PageSize { get; set; } = DEFAULT_PAGE_SIZE;
 
         [Parameter]
         public bool ColumnReorder { get; set; }
@@ -49,7 +51,7 @@ namespace BlazorTable
 
         public bool IsEditMode { get; private set; }
 
-        public int TotalPages => (TotalCount + PageSize - 1) / PageSize;
+        public int TotalPages => PageSize <= 0 ? 1 : (TotalCount + PageSize - 1) / PageSize;
 
         protected override void OnParametersSet()
         {
@@ -85,8 +87,11 @@ namespace BlazorTable
                         query = query.OrderBy(sortColumn.Field);
                     }
                 }
-
-                return query.Skip(PageNumber * PageSize).Take(PageSize).ToList();
+                // if PageSize is zero, we return all rows and no paging
+                if (PageSize <= 0)
+                    return query.ToList();
+                else                
+                    return query.Skip(PageNumber * PageSize).Take(PageSize).ToList();
             }
 
             return Items;


### PR DESCRIPTION
Fixes #47 - if PageSize is not set it would default to zero ( and probably have a divide by zero error on `TotalPages`). Changed to set PageSize default to 10, and change behaviour if page size <=0 to turn off paging.