### PR TITLE
Improve component accessibility with aria attributes

### DIFF
--- a/src/BlazorTable/Components/Pager.razor
+++ b/src/BlazorTable/Components/Pager.razor
@@ -18,15 +18,23 @@
             }
             @if ((ShowPageNumber || ShowTotalCount))
             {
-                <li class="page-item disabled">
+                <li aria-hidden="true" class="page-item disabled">
                     <a class="page-link" href="#" tabindex="-1" aria-disabled="true">&nbsp;</a>
                 </li>
             }
 
-            <li class="page-item @(Table.PageNumber == 0 ? "disabled": "")" @onclick="@(() => Table.FirstPage())" title="First"><a class="page-link" href="javascript:;">First</a></li>
-            <li class="page-item @(Table.PageNumber == 0 ? "disabled": "")" @onclick="@(() => Table.PreviousPage())" title="Previous"><a class="page-link" href="javascript:;">Previous</a></li>
-            <li class="page-item @(Table.PageNumber + 1 < Table.TotalPages ? "" : "disabled")" @onclick="@(() => Table.NextPage())" title="Next"><a class="page-link" href="javascript:;">Next</a></li>
-            <li class="page-item @(Table.PageNumber + 1 != Table.TotalPages ? "" : "disabled")" @onclick="@(() => Table.LastPage())" title="Last"><a class="page-link" href="javascript:;">Last</a></li>
+            <li class="page-item @(Table.PageNumber == 0 ? "disabled": "")" @onclick="@(() => Table.FirstPage())" title="First">
+                <a class="page-link" href="javascript:;" aria-disabled="@(Table.PageNumber == 0 ? "true": null)">First</a>
+            </li>
+            <li class="page-item @(Table.PageNumber == 0 ? "disabled": "")" @onclick="@(() => Table.PreviousPage())" title="Previous">
+                <a class="page-link" href="javascript:;" aria-disabled="@(Table.PageNumber == 0 ? "true": null)">Previous</a>
+            </li>
+            <li class="page-item @(Table.PageNumber + 1 < Table.TotalPages ? "" : "disabled")" @onclick="@(() => Table.NextPage())" title="Next">
+                <a class="page-link" href="javascript:;" aria-disabled="@(Table.PageNumber + 1 < Table.TotalPages ? null: "true")">Next</a>
+            </li>
+            <li class="page-item @(Table.PageNumber + 1 != Table.TotalPages ? "" : "disabled")" @onclick="@(() => Table.LastPage())" title="Last">
+                <a class="page-link" href="javascript:;" aria-disabled="@(Table.PageNumber + 1 != Table.TotalPages ? null : "true")">Last</a>
+            </li>
         </ul>
     </div>
 }

--- a/src/BlazorTable/Components/Table.razor
+++ b/src/BlazorTable/Components/Table.razor
@@ -4,10 +4,10 @@
 @if (Columns.Any())
 {
     <div class="table-responsive">
-        <table class="@TableClass" @attributes="UnknownParameters">
+        <table aria-readonly="@(IsEditMode ? "false" : "true")" role="grid" class="@TableClass" @attributes="UnknownParameters">
             @if (ShowSearchBar)
             {
-                <thead>
+                <thead role="search">
                     <tr>
                         <th colspan="@Columns.Count"><input type="text" class="form-control form-control-sm float-right" style="width:33%" value="@GlobalSearch" @onchange="@(x => { GlobalSearch = x.Value.ToString(); Update(); })" placeholder="Global Search..." /></th>
                     </tr>
@@ -24,12 +24,13 @@
                     }
                     @foreach (IColumn<TableItem> column in Columns)
                     {
-                        <th style="@(!string.IsNullOrEmpty(column.Width) ? $"width:{column.Width};" : "") user-select: none"
+                        <th scope="col" style="@(!string.IsNullOrEmpty(column.Width) ? $"width:{column.Width};" : "") user-select: none"
                             @ondrop="@(() => HandleDrop(column))"
                             @ondragstart="@(() => HandleDragStart(column))"
                             ondragover="event.preventDefault();"
                             draggable="@(ColumnReorder.ToString())"
                             @key="column"
+                            aria-sort="@column.AriaSort"
                             class="@(column.Class)">
 
                             <div @onclick="@(() => column.SortBy())">
@@ -38,15 +39,17 @@
                                 @if (column.SortColumn)
                                 {
                                     if (column.SortDescending)
-                                    {<span>&#11014;</span> }
+                                    {<span aria-hidden="true">&#11014;</span> }
                                     else
-                                    { <span>&#11015;</span>}
+                                    { <span aria-hidden="true">&#11015;</span>}
                                 }
 
                                 @if (column.Filterable)
                                 {
                                     <div class="float-right" @onclick="@((x) => column.ToggleFilter())" @onclick:stopPropagation>
-                                        <a href="javascript:;" @ref="column.FilterRef" style="text-decoration: none"><span style="@(column.Filter == null ? "opacity: 0.2;" : string.Empty)">&#128269;</span></a>
+                                        <a href="javascript:;" @ref="column.FilterRef" aria-expanded="@(column.FilterOpen ? "true" : "false")" style="text-decoration: none" aria-label="@(column.Filter == null ? "unfiltered" : "filtered")">
+                                            <span aria-hidden="true" style="@(column.Filter == null ? "opacity: 0.2;" : string.Empty)">&#128269;</span>
+                                        </a>
                                     </div>
                                     <CascadingValue Value="column" Name="Column">
                                         <Popover Reference="@column.FilterRef" IsOpen="@column.FilterOpen" Placement="Placement.Bottom" DismissOnNextClick="false">
@@ -81,13 +84,15 @@
 
                         foreach (TableItem item in FilteredItems)
                         {
-                            <tr @key="item" class="@RowClass(item) @(SelectedItems.Contains(item) ? "table-active" : "")" @onclick="(() => OnRowClickHandler(item))">
+                            <tr @key="item" aria-selected="@(SelectedItems.Contains(item) ? "true" : null)" class="@RowClass(item) @(SelectedItems.Contains(item) ? "table-active" : "")" @onclick="(() => OnRowClickHandler(item))">
 
                                 @{int locali = i;}
                                 @if (_detailTemplate != null)
                                 {
                                     <td>
-                                        <a href="javascript:;" style="text-decoration: none" @onclick="@(() => { detailsViewOpen[locali] = !detailsViewOpen[locali]; StateHasChanged(); })" title="Details View"><span style="">@(detailsViewOpen[locali] ? "➖" : "➕")</span></a>
+                                        <a href="javascript:;" style="text-decoration: none" @onclick="@(() => { detailsViewOpen[locali] = !detailsViewOpen[locali]; StateHasChanged(); })" title="Details View" aria-expanded="@(detailsViewOpen[locali] ? "true" : "false")">
+                                            <span style="">@(detailsViewOpen[locali] ? "➖" : "➕")</span>
+                                        </a>
                                     </td>
                                 }
 
@@ -100,7 +105,7 @@
                                         @if (IsEditMode && column.EditTemplate != null)
                                             @column.EditTemplate(item)
                                             else
-                                               if (column.Template == null)
+                                                  if (column.Template == null)
                                                 @column.Render(item)
                                                 else
                                                     @column.Template(item)

--- a/src/BlazorTable/Interfaces/IColumn.cs
+++ b/src/BlazorTable/Interfaces/IColumn.cs
@@ -103,6 +103,11 @@ namespace BlazorTable
         bool SortDescending { get; set; }
 
         /// <summary>
+        /// ARIA sort value, if any
+        /// </summary>
+        string AriaSort => SortColumn ? (SortDescending ? "descending" : "ascending") : null;
+
+        /// <summary>
         /// Horizontal alignment
         /// </summary>
         Align Align { get; set; }


### PR DESCRIPTION
As a blind blazor user, I stumbled upon this component and am really impressed by its intuitiveness. Unfortunately it had some accessibility issues, which this pr aims to solve.

* The grid role is now set on the table element, as these tables are really pretty interactive in their ability to sort/filter. Keyboard accessibility would be neat, but that's out of scope for now
* Selected rows get the aria-selected attribute
* Page navigation links that couldn't be navigated get the aria-disabled attribute
* Detail view and filter view expand/collapse toggles get aria-expanded true or false, respectively
* The fancy emoji shown for collapse/expand and filter toggles have been hidden from screen readers, as they aren't very descriptive. Instead, the filter toggle now tells the screen reader user whether a filter has been applied.
* Set the scope attribute on the main table headers
* Aria-sort is set for the sort column, either ascending or descending
* The search role is added to the search bar