### PR TITLE
Updated TableRowClass to Func<TableItem, string>

### DIFF
--- a/src/BlazorTable/Components/Table.razor.cs
+++ b/src/BlazorTable/Components/Table.razor.cs
@@ -43,7 +43,7 @@ namespace BlazorTable
         /// Expression to set Row Class
         /// </summary>
         [Parameter]
-        public Expression<Func<TableItem, string>> TableRowClass { get; set; }
+        public Func<TableItem, string> TableRowClass { get; set; }
 
         /// <summary>
         /// Page Size, defaults to 15
@@ -311,18 +311,8 @@ namespace BlazorTable
         /// <returns></returns>
         private string RowClass(TableItem item)
         {
-            if (TableRowClass == null) return null;
-
-            if (_tableRowClassCompiled == null)
-                _tableRowClassCompiled = TableRowClass.Compile();
-
-            return _tableRowClassCompiled.Invoke(item);
+            return TableRowClass?.Invoke(item);
         }
-
-        /// <summary>
-        /// Save compiled TableRowClass property to avoid repeated Compile() calls
-        /// </summary>
-        private Func<TableItem, string> _tableRowClassCompiled;
 
         /// <summary>
         /// Set the template to use for empty data


### PR DESCRIPTION
closes IvanJosipovic/BlazorTable#119

`Table.TableRowClass` has been updated from `Expression<Func<TableItem, string>>` to `Func<TableItem, string>`. This should help in cases where there could be multiple row classes that Expressions aren't able to handle effectively.

This is a breaking change for users who explicitly set TableRowClass to a property or method - their code needs to be updated from `Expression<Func<TableItem, string>>` to `Func<TableItem, string>`.