### PR TITLE
FooterTemplate , update to .net 5.0.2 and LinqKit to 1.1.23

### DIFF
--- a/src/BlazorTable/BlazorTable.csproj
+++ b/src/BlazorTable/BlazorTable.csproj
@@ -36,9 +36,9 @@
 
   <ItemGroup>
     <PackageReference Include="LINQKit.Core" Version="1.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorTable/BlazorTable.csproj
+++ b/src/BlazorTable/BlazorTable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <IsPackable>true</IsPackable>
     <Title>BlazorTable</Title>
@@ -36,9 +36,9 @@
 
   <ItemGroup>
     <PackageReference Include="LINQKit.Core" Version="1.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorTable/BlazorTable.csproj
+++ b/src/BlazorTable/BlazorTable.csproj
@@ -27,10 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LINQKit.Core" Version="1.1.23" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="5.0.2" />
+    <PackageReference Include="LINQKit.Core" Version="1.1.24" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="5.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorTable/BlazorTable.csproj
+++ b/src/BlazorTable/BlazorTable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <IsPackable>true</IsPackable>
     <Title>BlazorTable</Title>
@@ -17,6 +17,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="" />
     <Watch Include="..\**\*.razor" />
@@ -27,10 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LINQKit.Core" Version="1.1.24" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="5.0.4" />
+    <PackageReference Include="LINQKit.Core" Version="1.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorTable/BlazorTable.csproj
+++ b/src/BlazorTable/BlazorTable.csproj
@@ -35,10 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LINQKit.Core" Version="1.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.2" />
+    <PackageReference Include="LINQKit.Core" Version="1.2.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorTable/BlazorTable.csproj
+++ b/src/BlazorTable/BlazorTable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <IsPackable>true</IsPackable>
     <Title>BlazorTable</Title>
@@ -27,10 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LINQKit.Core" Version="1.1.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="3.1.11" />
+    <PackageReference Include="LINQKit.Core" Version="1.1.23" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="5.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorTable/BlazorTable.csproj
+++ b/src/BlazorTable/BlazorTable.csproj
@@ -36,9 +36,9 @@
 
   <ItemGroup>
     <PackageReference Include="LINQKit.Core" Version="1.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorTable/Components/Column.razor.cs
+++ b/src/BlazorTable/Components/Column.razor.cs
@@ -68,6 +68,13 @@ namespace BlazorTable
         public RenderFragment<TableItem> EditTemplate { get; set; }
 
         /// <summary>
+        /// Footer Template
+        /// </summary>
+        [Parameter]
+        public RenderFragment FooterTemplate { get; set; }
+
+
+        /// <summary>
         /// Set custom Footer column value 
         /// </summary>
         [Parameter]

--- a/src/BlazorTable/Components/Table.razor
+++ b/src/BlazorTable/Components/Table.razor
@@ -256,7 +256,11 @@
                         @foreach (IColumn<TableItem> column in Columns)
                         {
                             <td @key="column" style="@(column.Align > 0 ? $"text-align: {column.Align};" : "")" class="@(column.ColumnFooterClass)">
-                                @if (!string.IsNullOrEmpty(column.SetFooterValue))
+                                @if (!(column.FooterTemplate == null))
+                                {
+                                    @column.FooterTemplate;
+                                }
+                                else if (!string.IsNullOrEmpty(column.SetFooterValue))
                                 {
                                     @column.SetFooterValue
                                 }

--- a/src/BlazorTable/Interfaces/IColumn.cs
+++ b/src/BlazorTable/Interfaces/IColumn.cs
@@ -95,6 +95,10 @@ namespace BlazorTable
         RenderFragment<TableItem> Template { get; set; }
 
         /// <summary>
+        /// Edit Mode Item Template
+        /// </summary>
+        RenderFragment FooterTemplate { get; set; }
+        /// <summary>
         /// Set custom Footer column value 
         /// </summary>
         string SetFooterValue { get; set; }


### PR DESCRIPTION
Option to set a different template for the column footer using the  <FooterTemplate> tag +  update to .net 5.0.2 and LinqKit to 1.1.23.