### PR TITLE
Fix version conflicts caused by PR#324

### DIFF
--- a/src/BlazorTable.Sample.Wasm/BlazorTable.Sample.Wasm.csproj
+++ b/src/BlazorTable.Sample.Wasm/BlazorTable.Sample.Wasm.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.1" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Components.WebAssembly from 3.2.1 to 5.0.8. [(PR#324)](https://github.com/IvanJosipovic/BlazorTable/pull/324).
Hope this fix can help you.

Best regards,
sucrose